### PR TITLE
DRY up controller specs

### DIFF
--- a/spec/controllers/articles_controller_spec.rb
+++ b/spec/controllers/articles_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe ArticlesController, vcr: true do
-
   describe 'GET show' do
     context 'variable assignment' do
       context 'when successful' do
@@ -34,56 +33,26 @@ RSpec.describe ArticlesController, vcr: true do
   end
 
   describe '#data_check' do
-    context 'an available data format is requested' do
-      methods = [
+    let(:data_check_methods) do
+      [
         {
           route: 'show',
           parameters: { article_id: 'ccdwcKYM' },
           data_url: "#{ENV['PARLIAMENT_BASE_URL']}/webarticle_by_id?webarticle_id=ccdwcKYM"
         }
       ]
-
-      before(:each) do
-        headers = { 'Accept' => 'application/rdf+xml' }
-        request.headers.merge(headers)
-      end
-
-      it 'should have a response with http status redirect (302)' do
-        methods.each do |method|
-          if method.include?(:parameters)
-            get method[:route].to_sym, params: method[:parameters]
-          else
-            get method[:route].to_sym
-          end
-          expect(response).to have_http_status(302)
-        end
-      end
-
-      it 'redirects to the data service' do
-        methods.each do |method|
-          if method.include?(:parameters)
-            get method[:route].to_sym, params: method[:parameters]
-          else
-            get method[:route].to_sym
-          end
-          expect(response).to redirect_to(method[:data_url])
-        end
-      end
-
     end
+
+    it_behaves_like 'a data service request'
 
     context 'an unavailable data format is requested' do
       before(:each) do
         headers = { 'Accept' => 'application/foo' }
         request.headers.merge(headers)
       end
-
       it 'should raise ActionController::UnknownFormat error' do
         expect{ get :show, params: { article_id: 'ccdwcKYM' } }.to raise_error(ActionController::UnknownFormat)
       end
     end
   end
-
-
-
 end

--- a/spec/controllers/articles_controller_spec.rb
+++ b/spec/controllers/articles_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ArticlesController, vcr: true do
 
   describe '#data_check' do
     context 'an available data format is requested' do
-      METHODS = [
+      methods = [
         {
           route: 'show',
           parameters: { article_id: 'ccdwcKYM' },
@@ -49,7 +49,7 @@ RSpec.describe ArticlesController, vcr: true do
       end
 
       it 'should have a response with http status redirect (302)' do
-        METHODS.each do |method|
+        methods.each do |method|
           if method.include?(:parameters)
             get method[:route].to_sym, params: method[:parameters]
           else
@@ -60,7 +60,7 @@ RSpec.describe ArticlesController, vcr: true do
       end
 
       it 'redirects to the data service' do
-        METHODS.each do |method|
+        methods.each do |method|
           if method.include?(:parameters)
             get method[:route].to_sym, params: method[:parameters]
           else

--- a/spec/controllers/constituencies_controller_spec.rb
+++ b/spec/controllers/constituencies_controller_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe ConstituenciesController, vcr: true do
 
   describe '#data_check' do
     context 'an available data format is requested' do
-      METHODS = [
+      methods = [
         {
           route: 'lookup',
           parameters: { source: 'mnisId', id: '3274' },
@@ -184,7 +184,7 @@ RSpec.describe ConstituenciesController, vcr: true do
       end
 
       it 'should have a response with http status redirect (302)' do
-        METHODS.each do |method|
+        methods.each do |method|
           if method.include?(:parameters)
             get method[:route].to_sym, params: method[:parameters]
           else
@@ -195,7 +195,7 @@ RSpec.describe ConstituenciesController, vcr: true do
       end
 
       it 'redirects to the data service' do
-        METHODS.each do |method|
+        methods.each do |method|
           if method.include?(:parameters)
             get method[:route].to_sym, params: method[:parameters]
           else

--- a/spec/controllers/constituencies_controller_spec.rb
+++ b/spec/controllers/constituencies_controller_spec.rb
@@ -164,8 +164,8 @@ RSpec.describe ConstituenciesController, vcr: true do
   end
 
   describe '#data_check' do
-    context 'an available data format is requested' do
-      methods = [
+    let(:data_check_methods) do
+      [
         {
           route: 'lookup',
           parameters: { source: 'mnisId', id: '3274' },
@@ -177,35 +177,9 @@ RSpec.describe ConstituenciesController, vcr: true do
           data_url: "#{ENV['PARLIAMENT_BASE_URL']}/constituency_by_id?constituency_id=vUPobpVT"
         }
       ]
-
-      before(:each) do
-        headers = { 'Accept' => 'application/rdf+xml' }
-        request.headers.merge(headers)
-      end
-
-      it 'should have a response with http status redirect (302)' do
-        methods.each do |method|
-          if method.include?(:parameters)
-            get method[:route].to_sym, params: method[:parameters]
-          else
-            get method[:route].to_sym
-          end
-          expect(response).to have_http_status(302)
-        end
-      end
-
-      it 'redirects to the data service' do
-        methods.each do |method|
-          if method.include?(:parameters)
-            get method[:route].to_sym, params: method[:parameters]
-          else
-            get method[:route].to_sym
-          end
-          expect(response).to redirect_to(method[:data_url])
-        end
-      end
-
     end
+
+    it_behaves_like 'a data service request'
 
     context 'an unavailable data format is requested' do
       before(:each) do
@@ -218,5 +192,4 @@ RSpec.describe ConstituenciesController, vcr: true do
       end
     end
   end
-
 end

--- a/spec/controllers/contact_points_controller_spec.rb
+++ b/spec/controllers/contact_points_controller_spec.rb
@@ -27,43 +27,17 @@ RSpec.describe ContactPointsController, vcr: true do
     end
 
     describe '#data_check' do
-      context 'an available data format is requested' do
-        methods = [
-            {
-              route: 'show',
-              parameters: { contact_point_id: 'fFm9NQmr' },
-              data_url: "#{ENV['PARLIAMENT_BASE_URL']}/contact_point_by_id?contact_point_id=fFm9NQmr"
-            }
-          ]
-
-        before(:each) do
-          headers = { 'Accept' => 'application/rdf+xml' }
-          request.headers.merge(headers)
-        end
-
-        it 'should have a response with http status redirect (302)' do
-          methods.each do |method|
-            if method.include?(:parameters)
-              get method[:route].to_sym, params: method[:parameters]
-            else
-              get method[:route].to_sym
-            end
-            expect(response).to have_http_status(302)
-          end
-        end
-
-        it 'redirects to the data service' do
-          methods.each do |method|
-            if method.include?(:parameters)
-              get method[:route].to_sym, params: method[:parameters]
-            else
-              get method[:route].to_sym
-            end
-            expect(response).to redirect_to(method[:data_url])
-          end
-        end
-
+      let(:data_check_methods) do
+        [
+          {
+            route: 'show',
+            parameters: { contact_point_id: 'fFm9NQmr' },
+            data_url: "#{ENV['PARLIAMENT_BASE_URL']}/contact_point_by_id?contact_point_id=fFm9NQmr"
+          }
+        ]
       end
+
+      it_behaves_like 'a data service request'
     end
   end
 end

--- a/spec/controllers/houses/parties_controller_spec.rb
+++ b/spec/controllers/houses/parties_controller_spec.rb
@@ -34,41 +34,16 @@ RSpec.describe Houses::PartiesController, vcr: true do
   end
 
   describe '#data_check' do
-    context 'an available data format is requested' do
-      methods = [
+    let(:data_check_methods) do
+      [
         {
           route: 'show',
           parameters: { house_id: 'Kz7ncmrt', party_id: '891w1b1k' },
           data_url: "#{ENV['PARLIAMENT_BASE_URL']}/house_party_by_id?house_id=Kz7ncmrt&party_id=891w1b1k"
         }
-        ]
-
-      before(:each) do
-        headers = { 'Accept' => 'application/rdf+xml' }
-        request.headers.merge(headers)
-      end
-
-      it 'should have a response with http status redirect (302)' do
-        methods.each do |method|
-          if method.include?(:parameters)
-            get method[:route].to_sym, params: method[:parameters]
-          else
-            get method[:route].to_sym
-          end
-          expect(response).to have_http_status(302)
-        end
-      end
-
-      it 'redirects to the data service' do
-        methods.each do |method|
-          if method.include?(:parameters)
-            get method[:route].to_sym, params: method[:parameters]
-          else
-            get method[:route].to_sym
-          end
-          expect(response).to redirect_to(method[:data_url])
-        end
-      end
+      ]
     end
+
+    it_behaves_like 'a data service request'
   end
 end

--- a/spec/controllers/houses_controller_spec.rb
+++ b/spec/controllers/houses_controller_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe HousesController, vcr: true do
   end
 
   describe '#data_check' do
-    context 'an available data format is requested' do
-      methods = [
+    let(:data_check_methods) do
+      [
         {
           route: 'lookup',
           parameters: { source: 'name', id: 'House of Lords' },
@@ -53,33 +53,8 @@ RSpec.describe HousesController, vcr: true do
           data_url: "#{ENV['PARLIAMENT_BASE_URL']}/house_by_id?house_id=Kz7ncmrt"
         }
       ]
-
-      before(:each) do
-        headers = { 'Accept' => 'application/rdf+xml' }
-        request.headers.merge(headers)
-      end
-
-      it 'should have a response with http status redirect (302)' do
-        methods.each do |method|
-          if method.include?(:parameters)
-            get method[:route].to_sym, params: method[:parameters]
-          else
-            get method[:route].to_sym
-          end
-          expect(response).to have_http_status(302)
-        end
-      end
-
-      it 'redirects to the data service' do
-        methods.each do |method|
-          if method.include?(:parameters)
-            get method[:route].to_sym, params: method[:parameters]
-          else
-            get method[:route].to_sym
-          end
-          expect(response).to redirect_to(method[:data_url])
-        end
-      end
     end
+
+    it_behaves_like 'a data service request'
   end
 end

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -21,20 +21,16 @@ RSpec.describe MediaController, vcr: true do
   end
 
   describe '#data_check' do
-    context 'an available data format is requested' do
-      before(:each) do
-        headers = { 'Accept' => 'application/rdf+xml' }
-        request.headers.merge(headers)
-        get :show, params: { medium_id: 'qnsCGpnw' }
-      end
-
-      it 'should have a response with http status redirect (302)' do
-        expect(response).to have_http_status(302)
-      end
-
-      it 'redirects to the data service' do
-        expect(response).to redirect_to("#{ENV['PARLIAMENT_BASE_URL']}/image_by_id?image_id=qnsCGpnw")
-      end
+    let(:data_check_methods) do
+      [
+        {
+          route: 'show',
+          parameters: { medium_id: 'qnsCGpnw' },
+          data_url: "#{ENV['PARLIAMENT_BASE_URL']}/image_by_id?image_id=qnsCGpnw"
+        }
+      ]
     end
+
+    it_behaves_like 'a data service request'
   end
 end

--- a/spec/controllers/parliaments/houses/parties_controller_spec.rb
+++ b/spec/controllers/parliaments/houses/parties_controller_spec.rb
@@ -1,86 +1,62 @@
 require 'rails_helper'
 
 RSpec.describe Parliaments::Houses::PartiesController, vcr: true do
-    describe 'GET show' do
-      context '@party is nil' do
-        # updated VCR cassette in order to set @party to nil
-        it 'should raise ActionController::RoutingError' do
-          expect{get :show, params: { parliament_id: 'fHx6P1lb', house_id: 'Kz7ncmrt', party_id: '891w1b1k' }}.to raise_error(ActionController::RoutingError)
-        end
-      end
-
-      context '@party is not nil' do
-        before(:each) do
-          get :show, params: { parliament_id: 'fHx6P1lb', house_id: 'Kz7ncmrt', party_id: '891w1b1k' }
-        end
-
-        it 'should have a response with http status ok (200)' do
-          expect(response).to have_http_status(:ok)
-        end
-
-        context '@parliament' do
-          it 'assigns @parliament' do
-            expect(assigns(:parliament)).to be_a(Grom::Node)
-            expect(assigns(:parliament).type).to eq('https://id.parliament.uk/schema/ParliamentPeriod')
-          end
-        end
-
-        context '@house' do
-          it 'assigns @house' do
-            expect(assigns(:house)).to be_a(Grom::Node)
-            expect(assigns(:house).type).to eq('https://id.parliament.uk/schema/House')
-          end
-        end
-
-        context '@party' do
-          it 'assigns @party' do
-            expect(assigns(:party)).to be_a(Grom::Node)
-            expect(assigns(:party).type).to eq('https://id.parliament.uk/schema/Party')
-          end
-        end
-
-        it 'renders the house template' do
-          expect(response).to render_template('show')
-        end
+  describe 'GET show' do
+    context '@party is nil' do
+      # updated VCR cassette in order to set @party to nil
+      it 'should raise ActionController::RoutingError' do
+        expect{get :show, params: { parliament_id: 'fHx6P1lb', house_id: 'Kz7ncmrt', party_id: '891w1b1k' }}.to raise_error(ActionController::RoutingError)
       end
     end
 
-    describe '#data_check' do
-      context 'an available data format is requested' do
-        methods = [
-          {
-            route: 'show',
-            parameters: { parliament_id: 'fHx6P1lb', house_id: 'Kz7ncmrt', party_id: '891w1b1k' },
-            data_url: "#{ENV['PARLIAMENT_BASE_URL']}/parliament_house_party?parliament_id=fHx6P1lb&house_id=Kz7ncmrt&party_id=891w1b1k"
-          }
-        ]
+    context '@party is not nil' do
+      before(:each) do
+        get :show, params: { parliament_id: 'fHx6P1lb', house_id: 'Kz7ncmrt', party_id: '891w1b1k' }
+      end
 
-        before(:each) do
-          headers = { 'Accept' => 'application/rdf+xml' }
-          request.headers.merge(headers)
-        end
+      it 'should have a response with http status ok (200)' do
+        expect(response).to have_http_status(:ok)
+      end
 
-        it 'should have a response with http status redirect (302)' do
-          methods.each do |method|
-            if method.include?(:parameters)
-              get method[:route].to_sym, params: method[:parameters]
-            else
-              get method[:route].to_sym
-            end
-            expect(response).to have_http_status(302)
-          end
-        end
-
-        it 'redirects to the data service' do
-          methods.each do |method|
-            if method.include?(:parameters)
-              get method[:route].to_sym, params: method[:parameters]
-            else
-              get method[:route].to_sym
-            end
-            expect(response).to redirect_to(method[:data_url])
-          end
+      context '@parliament' do
+        it 'assigns @parliament' do
+          expect(assigns(:parliament)).to be_a(Grom::Node)
+          expect(assigns(:parliament).type).to eq('https://id.parliament.uk/schema/ParliamentPeriod')
         end
       end
+
+      context '@house' do
+        it 'assigns @house' do
+          expect(assigns(:house)).to be_a(Grom::Node)
+          expect(assigns(:house).type).to eq('https://id.parliament.uk/schema/House')
+        end
+      end
+
+      context '@party' do
+        it 'assigns @party' do
+          expect(assigns(:party)).to be_a(Grom::Node)
+          expect(assigns(:party).type).to eq('https://id.parliament.uk/schema/Party')
+        end
+      end
+
+      it 'renders the house template' do
+        expect(response).to render_template('show')
+      end
     end
+  end
+
+  describe '#data_check' do
+
+    let(:data_check_methods) do
+      [
+        {
+          route: 'show',
+          parameters: { parliament_id: 'fHx6P1lb', house_id: 'Kz7ncmrt', party_id: '891w1b1k' },
+          data_url: "#{ENV['PARLIAMENT_BASE_URL']}/parliament_house_party?parliament_id=fHx6P1lb&house_id=Kz7ncmrt&party_id=891w1b1k"
+        }
+      ]
+    end
+
+    it_behaves_like 'a data service request'
+  end
 end

--- a/spec/controllers/parliaments/houses_controller_spec.rb
+++ b/spec/controllers/parliaments/houses_controller_spec.rb
@@ -35,42 +35,16 @@ RSpec.describe Parliaments::HousesController, vcr: true do
   end
 
   describe '#data_check' do
-    context 'an available data format is requested' do
-      methods = [
-          {
-            route: 'show',
-            parameters: { parliament_id: 'fHx6P1lb', house_id: 'Kz7ncmrt' },
-            data_url: "#{ENV['PARLIAMENT_BASE_URL']}/parliament_house?parliament_id=fHx6P1lb&house_id=Kz7ncmrt"
-          }
-        ]
-
-      before(:each) do
-        headers = { 'Accept' => 'application/rdf+xml' }
-        request.headers.merge(headers)
-      end
-
-      it 'should have a response with http status redirect (302)' do
-        methods.each do |method|
-          if method.include?(:parameters)
-            get method[:route].to_sym, params: method[:parameters]
-          else
-            get method[:route].to_sym
-          end
-          expect(response).to have_http_status(302)
-        end
-      end
-
-      it 'redirects to the data service' do
-        methods.each do |method|
-          if method.include?(:parameters)
-            get method[:route].to_sym, params: method[:parameters]
-          else
-            get method[:route].to_sym
-          end
-          expect(response).to redirect_to(method[:data_url])
-        end
-      end
-
+    let(:data_check_methods) do
+      [
+        {
+          route: 'show',
+          parameters: { parliament_id: 'fHx6P1lb', house_id: 'Kz7ncmrt' },
+          data_url: "#{ENV['PARLIAMENT_BASE_URL']}/parliament_house?parliament_id=fHx6P1lb&house_id=Kz7ncmrt"
+        }
+      ]
     end
+
+    it_behaves_like 'a data service request'
   end
 end

--- a/spec/controllers/parliaments/parties_controller_spec.rb
+++ b/spec/controllers/parliaments/parties_controller_spec.rb
@@ -39,42 +39,16 @@ RSpec.describe Parliaments::PartiesController, vcr: true do
   end
 
   describe '#data_check' do
-    context 'an available data format is requested' do
-      methods = [
-          {
-            route: 'show',
-            parameters: { parliament_id: 'fHx6P1lb', party_id: '891w1b1k' },
-            data_url: "#{ENV['PARLIAMENT_BASE_URL']}/parliament_party?parliament_id=fHx6P1lb&party_id=891w1b1k"
-          }
-        ]
-
-      before(:each) do
-        headers = { 'Accept' => 'application/rdf+xml' }
-        request.headers.merge(headers)
-      end
-
-      it 'should have a response with http status redirect (302)' do
-        methods.each do |method|
-          if method.include?(:parameters)
-            get method[:route].to_sym, params: method[:parameters]
-          else
-            get method[:route].to_sym
-          end
-          expect(response).to have_http_status(302)
-        end
-      end
-
-      it 'redirects to the data service' do
-        methods.each do |method|
-          if method.include?(:parameters)
-            get method[:route].to_sym, params: method[:parameters]
-          else
-            get method[:route].to_sym
-          end
-          expect(response).to redirect_to(method[:data_url])
-        end
-      end
-
+    let(:data_check_methods) do
+      [
+        {
+          route: 'show',
+          parameters: { parliament_id: 'fHx6P1lb', party_id: '891w1b1k' },
+          data_url: "#{ENV['PARLIAMENT_BASE_URL']}/parliament_party?parliament_id=fHx6P1lb&party_id=891w1b1k"
+        }
+      ]
     end
+
+    it_behaves_like 'a data service request'
   end
 end

--- a/spec/controllers/parliaments_controller_spec.rb
+++ b/spec/controllers/parliaments_controller_spec.rb
@@ -180,8 +180,8 @@ RSpec.describe ParliamentsController, vcr: true do
   end
 
   describe '#data_check' do
-    context 'an available data format is requested' do
-      methods = [
+    let(:data_check_methods) do
+      [
         {
           route: 'show',
           parameters: { parliament_id: 'fHx6P1lb' },
@@ -214,36 +214,11 @@ RSpec.describe ParliamentsController, vcr: true do
           parameters: { parliament_id: 'fHx6P1lb' },
           data_url: "#{ENV['PARLIAMENT_BASE_URL']}/previous_parliament_by_id?parliament_id=fHx6P1lb"
         }
-        ]
-
-      before(:each) do
-        headers = { 'Accept' => 'application/rdf+xml' }
-        request.headers.merge(headers)
-      end
-
-      it 'should have a response with http status redirect (302)' do
-        methods.each do |method|
-          if method.include?(:parameters)
-            get method[:route].to_sym, params: method[:parameters]
-          else
-            get method[:route].to_sym
-          end
-          expect(response).to have_http_status(302)
-        end
-      end
-
-      it 'redirects to the data service' do
-        methods.each do |method|
-          if method.include?(:parameters)
-            get method[:route].to_sym, params: method[:parameters]
-          else
-            get method[:route].to_sym
-          end
-          expect(response).to redirect_to(method[:data_url])
-        end
-      end
-
+      ]
     end
+
+    it_behaves_like 'a data service request'
+
     describe 'next' do
       context '@parliament is nil' do
         # updated VCR cassette in order to set @parliament to nil

--- a/spec/controllers/parties_controller_spec.rb
+++ b/spec/controllers/parties_controller_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe PartiesController, vcr: true do
   end
 
   describe '#data_check' do
-    context 'an available data format is requested' do
-      methods = [
+    let(:data_check_methods) do
+      [
         {
           route: 'show',
           parameters: { party_id: '891w1b1k' },
@@ -52,34 +52,9 @@ RSpec.describe PartiesController, vcr: true do
           parameters: { source: 'mnisId', id: '96' },
           data_url: "#{ENV['PARLIAMENT_BASE_URL']}/party_lookup?property=mnisId&value=96"
         }
-        ]
-
-      before(:each) do
-        headers = { 'Accept' => 'application/rdf+xml' }
-        request.headers.merge(headers)
-      end
-
-      it 'should have a response with http status redirect (302)' do
-        methods.each do |method|
-          if method.include?(:parameters)
-            get method[:route].to_sym, params: method[:parameters]
-          else
-            get method[:route].to_sym
-          end
-          expect(response).to have_http_status(302)
-        end
-      end
-
-      it 'redirects to the data service' do
-        methods.each do |method|
-          if method.include?(:parameters)
-            get method[:route].to_sym, params: method[:parameters]
-          else
-            get method[:route].to_sym
-          end
-          expect(response).to redirect_to(method[:data_url])
-        end
-      end
+      ]
     end
+
+    it_behaves_like 'a data service request'
   end
 end

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -145,8 +145,8 @@ RSpec.describe PeopleController, vcr: true do
   end
 
   describe '#data_check' do
-    context 'an available data format is requested' do
-      methods = [
+    let(:data_check_methods) do
+      [
         {
           route: 'show',
           parameters: { person_id: 'toes2sa2' },
@@ -157,35 +157,10 @@ RSpec.describe PeopleController, vcr: true do
           parameters: { source: 'mnisId', id: '3299' },
           data_url: "#{ENV['PARLIAMENT_BASE_URL']}/person_lookup?property=mnisId&value=3299"
         }
-        ]
-
-      before(:each) do
-        headers = { 'Accept' => 'application/rdf+xml' }
-        request.headers.merge(headers)
-      end
-
-      it 'should have a response with http status redirect (302)' do
-        methods.each do |method|
-          if method.include?(:parameters)
-            get method[:route].to_sym, params: method[:parameters]
-          else
-            get method[:route].to_sym
-          end
-          expect(response).to have_http_status(302)
-        end
-      end
-
-      it 'redirects to the data service' do
-        methods.each do |method|
-          if method.include?(:parameters)
-            get method[:route].to_sym, params: method[:parameters]
-          else
-            get method[:route].to_sym
-          end
-          expect(response).to redirect_to(method[:data_url])
-        end
-      end
+      ]
     end
+
+    it_behaves_like 'a data service request'
   end
 
   # Test for ApplicationController Parliament::ClientError handling

--- a/spec/controllers/places_controller_spec.rb
+++ b/spec/controllers/places_controller_spec.rb
@@ -28,41 +28,16 @@ RSpec.describe PlacesController, vcr: true do
   end
 
   describe '#data_check' do
-    context 'an available data format is requested' do
-      methods = [
+    let(:data_check_methods) do
+      [
         {
           route: 'show',
           parameters: { place_id: 'E15000001' },
           data_url: "#{ENV['PARLIAMENT_BASE_URL']}/region_by_id?region_code=E15000001"
         }
       ]
-
-      before(:each) do
-        headers = { 'Accept' => 'application/rdf+xml' }
-        request.headers.merge(headers)
-      end
-
-      it 'should have a response with http status redirect (302)' do
-        methods.each do |method|
-          if method.include?(:parameters)
-            get method[:route].to_sym, params: method[:parameters]
-          else
-            get method[:route].to_sym
-          end
-          expect(response).to have_http_status(302)
-        end
-      end
-
-      it 'redirects to the data service' do
-        methods.each do |method|
-          if method.include?(:parameters)
-            get method[:route].to_sym, params: method[:parameters]
-          else
-            get method[:route].to_sym
-          end
-          expect(response).to redirect_to(method[:data_url])
-        end
-      end
     end
+
+    it_behaves_like 'a data service request'
   end
 end

--- a/spec/support/controllers/shared_examples.rb
+++ b/spec/support/controllers/shared_examples.rb
@@ -1,0 +1,32 @@
+RSpec.shared_examples 'a data service request' do
+  context 'an available data format is requested' do
+    before(:each) do
+      try(:data_check_methods) || raise('Missing `let` for :data_check_methods used in shared examples')
+
+      headers = { 'Accept' => 'application/rdf+xml' }
+      request.headers.merge(headers)
+    end
+
+    it 'should have a response with http status redirect (302)' do
+      data_check_methods.each do |method|
+        if method.include?(:parameters)
+          get method[:route].to_sym, params: method[:parameters]
+        else
+          get method[:route].to_sym
+        end
+        expect(response).to have_http_status(302)
+      end
+    end
+
+    it 'redirects to the data service' do
+      data_check_methods.each do |method|
+        if method.include?(:parameters)
+          get method[:route].to_sym, params: method[:parameters]
+        else
+          get method[:route].to_sym
+        end
+        expect(response).to redirect_to(method[:data_url])
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Background ###
Originally this branch was intended just to fix the failing rspec tests for the ArticleController - the original issue was because the spec, like the spec for ConstituenciesController, used a constant `METHODS` instead of a scoped variable `methods` as per other specs. 

However, on reflection, it seemed sensible to DRY up the code surrounding the data service requests which were repeated in all controller specs; so that's what I've done 😁 .

-----------

Other notes;
- Shared Examples don't play nicely with a variable called `methods`, so I've swapped it for `data_service_methods`
- 2 controller specs (Articles and Constituencies) have an additional context `an unavailable data format is requested` but this wasn't shared with other controllers, so I've kept it in their own controller specs.
- The `Parliament::Houses::PartiesController` spec had an indentation issue which I also fixed.